### PR TITLE
kernelspecs sort by display_name

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -88,7 +88,7 @@ export class KernelManager {
 
   async update() {
     const kernelSpecs = await ks.findAll();
-    this.kernelSpecs = _.map(kernelSpecs, "spec");
+    this.kernelSpecs = _.sortBy(_.map(kernelSpecs, "spec"), spec => spec.display_name);
     return this.kernelSpecs;
   }
 


### PR DESCRIPTION
To avoid inconsistent ordering of kernels, and allow users to dictate which kernels appear first, sort the kernel specs by their display_name.

I generate a lot of separate kernels with pipenv, and this is helpful to ensure that the default kernels remain at the top of the modal list. 